### PR TITLE
Extra calls for setting and removing delays!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Idea project folder
+.idea/

--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ Content body
          "responseHeaders": {
              "Authorization": "Bearer ABCDEFABCDEFABCDEFABCDEFABCDEF",
              "X-Proxickls": "Some Mock Response Header"
-         }
+         },
+         delay : 2000
      }
 
-  * Clearing all mock responses can be cleared with sending a DELETE call to http://localhost:5080/clearAllMockResponses
-  * Clearing a specific mock response can be done by sending a DELETE call to http://localhost:5080/clearMockResponse with the following JSON structure as body:
+Setting a delay is optional!
+
+  * Clearing all mock responses can be cleared with sending a DELETE call to http://localhost:5080/proxy/clearAllMockResponses
+  * Clearing a specific mock response can be done by sending a DELETE call to http://localhost:5080/proxy/clearMockResponse with the following JSON structure as body:
      {
          "url": "/the/url/to/override"
      }
+  * Clearing all delays can be done by sending a DELETE call to http://localhost:5080/proxy/clearDelays
 
 
 #### Clear a specific mock response
@@ -58,10 +62,17 @@ Content body
 
 ``Method:`` **DELETE**
 
+#### Clear all delays
+
+Clear all delays. Does NOT clear any mock responses however!
+
+``/proxy/clearAllDelays``
+
+``Method:`` **DELETE**
 
 #### List proxied requests
 
-Generate a list of all the requests that have been proxied through the proxy server.
+Generate a list of all the requests that have been proxied through the proxy server and their responses (if any)
 
 ``/proxy/listProxiedRequests?limit=50``
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A lightweight HTTP(S) mock proxy aimed at mocking responses of REST APIs for fro
 
 ``node bin/index --target=http://targethost.com --port=5001 (optional)``
 
-Where ``port`` is the port the proxy server will listen on.
+Where ``port`` is the port the proxy server will listen on and ``target`` is the server to which calls that are not mocked will be proxied.
 
 
-#### Settings a mock response
+#### Setting a mock response
 
 ``/proxy/setMockResponse``
 
@@ -42,6 +42,29 @@ Setting a delay is optional!
          "url": "/the/url/to/override"
      }
   * Clearing all delays can be done by sending a DELETE call to http://localhost:5080/proxy/clearDelays
+
+#### Setting multiple delays
+
+Set multiple delays at once. This will also affect existing mock responses!
+
+``/proxy/setMockResponse``
+
+``Method:`` **POST**
+
+Content body
+
+     {
+         "delays": [
+             {
+                "url": "/url",
+                "delay": 2000
+             },
+             {
+                "url": "/anotherurl",
+                "delay": 5000
+             }
+          ]
+     }
 
 
 #### Clear a specific mock response
@@ -83,6 +106,8 @@ Generate a list of all the requests that have been proxied through the proxy ser
 ``limit`` The maximum number of requests (defaults to unlimited)
 
 #### Clear the list of proxied calls
+
+``Method:`` **DELETE**
 
 ``/proxy/clearProxiedCalls``
 

--- a/lib/proxicle.js
+++ b/lib/proxicle.js
@@ -297,6 +297,12 @@ module.exports = {
             error("Proxy error: " + err);
         });
 
+        proxy.on('proxyRes', function (proxyRes, req, res) {
+            var res = proxiedRequests[req.id].res;
+            res.headers = proxyRes.headers
+            res.date = new Date();
+        });
+
         var server = http.createServer(function(req, res) {
 
             if(!handleProxyOverrideRequest(req, res)) {
@@ -322,11 +328,16 @@ module.exports = {
                     proxyLog("Proxying request " + req.url);
 
                     try {
+
+                        req.id = proxiedRequests.length;
+
                         proxiedRequests.push({
-                            date:       new Date(),
-                            url:        req.url,
-                            headers:    req.headers,
-                            method:     req.method//,
+                            req: {
+                                date: new Date(),
+                                url: req.url,
+                                headers: req.headers,
+                                method: req.method
+                            }, res: {}
                         });
 
                         if(secureTarget) {


### PR DESCRIPTION
Bert would also like to be able to set delays for URLs separately and delete them. Implemented an associative array in the spirit of `mockResponses` that takes care of this. We've done extensive testing and the application behaves properly!